### PR TITLE
Fixed time formatting

### DIFF
--- a/src/Chirp.CLI.Client/Cheep.cs
+++ b/src/Chirp.CLI.Client/Cheep.cs
@@ -6,7 +6,7 @@
         {
             DateTime time = new DateTime(1970, 1, 1);
             time = time.AddSeconds(Timestamp);
-            var strTime = time.ToLocalTime().ToString("dd-MM-yyyy HH:mm:ss");
+            var strTime = time.ToLocalTime().ToString("dd-MM-yyyy HH':'mm':'ss");
             
             return Author + " @ " + strTime + ": " + Message ;
         }


### PR DESCRIPTION
We use `:` unescaped in the formatting string in `Cheep.cs`. That's a reserved character which is automatically translated into the user's own equivalent, meaning tests that validate the output of `Cheep.ToString()` currently break on some machines.

I fixed it by escaping them; it's just a single-quotation mark on either side of them.