### PR TITLE
Automatic upload to Azure

### DIFF
--- a/.github/workflows/main_bdsagroup7chirpremotedb.yml
+++ b/.github/workflows/main_bdsagroup7chirpremotedb.yml
@@ -24,10 +24,10 @@ jobs:
           dotnet-version: '9.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build src/Chirp.CSVDBService/ --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish src/Chirp.CSVDBService/ -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I used the very useful guide that was given to us to make this worklow. The worklow was made using the azure wepsite and directly added to main, so this pull request looks smaller than it is so insted just think of this pull request as having added the file main_bdsagroup7chirpremotedb.yml file. 

This new action triggers whenever something is pushed to main. It then deploys to Azure. The Action can also manualy be triggerd by  going to github.com -> Actions ->Build and deploy ASP.Net -> run worklow and then choosing what workflow it should deploy

Closes #30