### PR TITLE
created `AuthorRepository.cs` and `AuthorService.cs`

### DIFF
--- a/src/Chirp.Core/IAuthorRepository.cs
+++ b/src/Chirp.Core/IAuthorRepository.cs
@@ -1,0 +1,33 @@
+namespace Chirp.Core;
+
+using Domain_Model;
+
+public interface IAuthorRepository
+{
+    
+    public Task CreateAuthor(string name, string email);
+    
+    /**
+     * recognizes the string as a name or email and calls the relevant GetAuthor method
+     */
+    public Task<List<Author>> GetAuthor(string identifier);
+
+    /**
+     * Function used in GetAuthor if its argument is recognized as an Email.
+     */
+    public Task<List<Author>> GetAuthorByEmail(string email);
+
+    /**
+     * Function used in GetAuthor if its argument is recognized as a name.
+     */
+    public Task<List<Author>> GetAuthorByUserName(string username);
+
+    public Task Follow(Author follower, Author followed);
+    /**
+     * Deletes a follow relation
+     */
+    public Task Unfollow(Author follower, Author followed);
+
+    public Task<List<FollowRelation>> GetFollowRelations(Author author);
+    public Task<List<Author>> Following(Author author);
+}

--- a/src/Chirp.Core/ICheepRepository.cs
+++ b/src/Chirp.Core/ICheepRepository.cs
@@ -5,20 +5,6 @@ using Domain_Model;
 public interface ICheepRepository
 {
     /**
-     * recognizes the string as a name or email and calls the relevant GetAuthor method
-     */
-    public Task<List<Author>> GetAuthor(string identifier);
-
-    /**
-     * Function used in GetAuthor if its argument is recognized as an Email.
-     */
-    public Task<List<Author>> GetAuthorByEmail(string email);
-
-    /**
-     * Function used in GetAuthor if its argument is recognized as a name.
-     */
-    public Task<List<Author>> GetAuthorByUserName(string username);
-    /**
      * Gets all cheeps within the given page nr
      */
     public Task<List<CheepDTO>> GetCheeps(int pageNr);
@@ -28,19 +14,9 @@ public interface ICheepRepository
      */
     public Task<List<CheepDTO>> GetCheepsFromUserName(string username, int pageNr);
 
-    public Task CreateAuthor(string name, string email);
-
+    
     public Task CreateCheep(Author author, string message, DateTime timestamp);
     /**
      * Creates a follow relation, and adds a reference of the followed to follower
      */
-    public Task Follow(Author follower, Author followed);
-    /**
-     * Deletes a follow relation
-     */
-    public Task Unfollow(Author follower, Author followed);
-
-    public Task<List<FollowRelation>> GetFollowRelations(Author author);
-    public Task<List<Author>> Following(Author author);
-
 }

--- a/src/Chirp.Infrastructure/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/AuthorRepository.cs
@@ -1,0 +1,106 @@
+namespace Chirp.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+using Chirp.Core;
+using Chirp.Core.Domain_Model;
+using Microsoft.EntityFrameworkCore;
+
+public class AuthorRepository :  IAuthorRepository
+{
+    private ChirpDBContext _dbContext;
+
+    public AuthorRepository(ChirpDBContext dbContext)
+    {
+        this._dbContext = dbContext;
+    }
+
+    public async Task CreateAuthor(string name, string email)
+    {
+        var author = Author.Create(name, email);
+        await _dbContext.Authors.AddAsync(author);
+        await _dbContext.SaveChangesAsync();
+    }
+    public async Task<List<Author>> GetAuthor(string identifier)
+    {
+        if (identifier.Contains("@"))
+        {
+            return await GetAuthorByEmail(identifier);
+        }
+        return await GetAuthorByUserName(identifier);
+    }
+
+    public async Task<List<Author>> GetAuthorByUserName(string username)
+    {
+        var query = (from author in _dbContext.Authors
+            where author.UserName == username
+            orderby author.DisplayName
+            select author);
+        return await query.ToListAsync();
+    }
+
+    public async Task<List<Author>> GetAuthorByEmail(string email)
+    {
+        var query = (from author in _dbContext.Authors
+            where author.Email == email
+            orderby author.DisplayName
+            select author);
+        return await query.ToListAsync();
+    }
+
+    public async Task Follow(Author follower, Author followed)
+    {
+        if (await ValidifyfollowRelationAsync(follower, followed))
+        {
+            return;
+        }
+        FollowRelation newFollowRelation = new FollowRelation() { Follower = follower, Followed = followed };
+        await _dbContext.AddAsync(newFollowRelation);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task Unfollow(Author followerToDelete, Author followedToDelete)
+    {
+        FollowRelation followRelationToDelete = (from followRelation in _dbContext.FollowRelations
+        where followRelation.Follower == followerToDelete && followRelation.Followed == followedToDelete
+        select followRelation).First();
+        if (followedToDelete == null)
+        {
+            return;
+        }
+        _dbContext.FollowRelations.Remove(followRelationToDelete);
+        await _dbContext.SaveChangesAsync();
+    }
+    /**
+     * Returns true if breaks rules
+     */
+    private async Task<bool> ValidifyfollowRelationAsync(Author follower, Author followed)
+    {
+        if (!_dbContext.Authors.Any(author => author == follower)||
+            !_dbContext.Authors.Any(author => author == followed)||
+            follower.Id == followed.Id|| 
+            (await Following(follower)).Contains(followed)) //checks if follower already follows followed :3
+        { 
+            return true;
+        }
+        return false;   
+    }
+    /**
+     * returns all FollowRelations where `author` is follower 
+     */
+    public async Task<List<FollowRelation>> GetFollowRelations(Author author)
+    {
+        return await (from followRelation in _dbContext.FollowRelations
+        where followRelation.Follower == author
+        select followRelation).ToListAsync();
+    }
+
+    /**
+     * this is borderline unreadable, but it just gets all Authors which `author` follows
+     */
+    public async Task<List<Author>> Following(Author author)
+    {
+        return(from user in _dbContext.FollowRelations
+                where user.Follower.UserName == author.UserName
+                select user.Followed).ToList();
+    }
+}

--- a/src/Chirp.Infrastructure/AuthorService.cs
+++ b/src/Chirp.Infrastructure/AuthorService.cs
@@ -1,0 +1,16 @@
+using Chirp.Core;
+using Chirp.Core.Domain_Model;
+using Chirp.Infrastructure;
+
+public class AuthorService : IAuthorService
+{
+    private IAuthorRepository authorRepository;
+    public AuthorService(IAuthorRepository authorRepository)
+    {
+        this.authorRepository = authorRepository;
+    }
+    public async Task<List<Author>> GetAuthorByUserName(string username)
+    {
+        return await authorRepository.GetAuthorByUserName(username);
+    }
+}

--- a/src/Chirp.Infrastructure/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/CheepRepository.cs
@@ -17,40 +17,6 @@ public class CheepRepository :  ICheepRepository
         this._dbContext = dbContext;
     }
 
-    public async Task<List<Author>> GetAuthor(string identifier)
-    {
-        if (identifier.Contains("@"))
-        {
-            return await GetAuthorByEmail(identifier);
-        }
-        return await GetAuthorByUserName(identifier);
-    }
-
-    public async Task<List<Author>> GetAuthorByUserName(string username)
-    {
-        var query = (from author in _dbContext.Authors
-            where author.UserName == username
-            orderby author.DisplayName
-            select author);
-        return await query.ToListAsync();
-    }
-
-    public async Task<List<Author>> GetAuthorByEmail(string email)
-    {
-        var query = (from author in _dbContext.Authors
-            where author.Email == email
-            orderby author.DisplayName
-            select author);
-        return await query.ToListAsync();
-    }
-
-    public async Task CreateAuthor(string name, string email)
-    {
-        var author = Author.Create(name, email);
-        await _dbContext.Authors.AddAsync(author);
-        await _dbContext.SaveChangesAsync();
-    }
-
     public async Task CreateCheep(Author author, string message, DateTime timestamp)
     {
         if (message.Length > Cheep.MAX_TEXT_LENGTH) {
@@ -91,60 +57,4 @@ public class CheepRepository :  ICheepRepository
         return await query.ToListAsync();
     }
 
-    public async Task Follow(Author follower, Author followed)
-    {
-        if (await ValidifyfollowRelationAsync(follower, followed))
-        {
-            return;
-        }
-        FollowRelation newFollowRelation = new FollowRelation() { Follower = follower, Followed = followed };
-        await _dbContext.AddAsync(newFollowRelation);
-        _dbContext.SaveChanges();
-    }
-
-    public async Task Unfollow(Author followerToDelete, Author followedToDelete)
-    {
-        FollowRelation followRelationToDelete = (from followRelation in _dbContext.FollowRelations
-        where followRelation.Follower == followerToDelete && followRelation.Followed == followedToDelete
-        select followRelation).First();
-        if (followedToDelete == null)
-        {
-            return;
-        }
-        _dbContext.FollowRelations.Remove(followRelationToDelete);
-        _dbContext.SaveChanges();
-    }
-    /**
-     * Returns true if breaks rules
-     */
-    private async Task<bool> ValidifyfollowRelationAsync(Author follower, Author followed)
-    {
-        if (!_dbContext.Authors.Any(author => author == follower)||
-            !_dbContext.Authors.Any(author => author == followed)||
-            follower.Id == followed.Id|| 
-            (await Following(follower)).Contains(followed)) //checks if follower already follows followed :3
-        { 
-            return true;
-        }
-        return false;   
-    }
-    /**
-     * returns all FollowRelations where `author` is follower 
-     */
-    public async Task<List<FollowRelation>> GetFollowRelations(Author author)
-    {
-        return await (from followRelation in _dbContext.FollowRelations
-        where followRelation.Follower == author
-        select followRelation).ToListAsync();
-    }
-
-    /**
-     * this is borderline unreadable, but it just gets all Authors which `author` follows
-     */
-    public async Task<List<Author>> Following(Author author)
-    {
-        return(from user in _dbContext.FollowRelations
-                where user.Follower.UserName == author.UserName
-                select user.Followed).ToList();
-    }
 }

--- a/src/Chirp.Infrastructure/CheepService.cs
+++ b/src/Chirp.Infrastructure/CheepService.cs
@@ -29,10 +29,6 @@ public class CheepService : ICheepService
         return await cheepRepository.GetCheepsFromUserName(username, pageNr);
     }
 
-    public async Task<List<Author>> GetAuthorByUserName(string username)
-    {
-        return await cheepRepository.GetAuthorByUserName(username);
-    }
     public async Task CreateCheep(Author author, string message)
     {
         DateTime date = DateTime.Now;

--- a/src/Chirp.Infrastructure/IAuthorService.cs
+++ b/src/Chirp.Infrastructure/IAuthorService.cs
@@ -1,0 +1,9 @@
+using Chirp.Core;
+using Chirp.Core.Domain_Model;
+
+namespace Chirp.Infrastructure;
+
+public interface IAuthorService
+{
+    public Task<List<Author>> GetAuthorByUserName(string username);
+}

--- a/src/Chirp.Infrastructure/ICheepService.cs
+++ b/src/Chirp.Infrastructure/ICheepService.cs
@@ -7,6 +7,5 @@ public interface ICheepService
 {
     public Task<List<CheepDTO>> GetCheeps(int pageNr);
     public Task<List<CheepDTO>> GetCheepsFromUserName(string username, int pageNr);
-    public Task<List<Author>> GetAuthorByUserName(string username);
     public Task CreateCheep(Author author, string message);
 }

--- a/src/Chirp.Web/CheepTimelineModel.cs
+++ b/src/Chirp.Web/CheepTimelineModel.cs
@@ -12,7 +12,8 @@ namespace Chirp.Web;
 // this class should contain everything that these classes should share
 public abstract class CheepTimelineModel : PageModel
 {
-    protected readonly ICheepService _service;
+    protected readonly ICheepService _cheepService;
+    protected readonly IAuthorService _authorService;
     public List<CheepDTO> Cheeps { get; set; } = new();
 
     [BindProperty]
@@ -22,9 +23,10 @@ public abstract class CheepTimelineModel : PageModel
     [Display(Name = "Message")]
     public string Text { get; set; } = "";
 
-    public CheepTimelineModel(ICheepService service)
+    public CheepTimelineModel(ICheepService _cheepService, IAuthorService _authorService)
     {
-        _service = service;
+        this._cheepService = _cheepService;
+        this._authorService = _authorService;
     }
 
     /**
@@ -43,7 +45,7 @@ public abstract class CheepTimelineModel : PageModel
 
     public async Task OnPostAsync()
     {
-        _ = _service.CreateCheep((await _service.GetAuthorByUserName(User.Identity!.Name!)).First(), Text);
+        _ = _cheepService.CreateCheep((await _authorService.GetAuthorByUserName(User.Identity!.Name!)).First(), Text);
         Response.Redirect(Request.GetDisplayUrl());
     }
 }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -5,7 +5,7 @@ namespace Chirp.Web.Pages;
 
 public class PublicModel : CheepTimelineModel
 {
-    public PublicModel(ICheepService service) : base(service)
+    public PublicModel(ICheepService cheepService, IAuthorService authorService) : base(cheepService, authorService)
     {
     }
 
@@ -13,7 +13,7 @@ public class PublicModel : CheepTimelineModel
     {
         int pageNr = getPageNr(Request);
 
-        Cheeps = await _service.GetCheeps(pageNr);
+        Cheeps = await _cheepService.GetCheeps(pageNr);
         return Page();
     }
 }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -12,8 +12,8 @@ public class UserTimelineModel : CheepTimelineModel
     public Author? Author { get; set; }
     public string Header { get; set; } = NO_USER_HEADER;
 
-    public UserTimelineModel(ICheepService service, UserManager<Author> userManager)
-        : base(service)
+    public UserTimelineModel(ICheepService cheepService, IAuthorService authorService, UserManager<Author> userManager)
+        : base(cheepService, authorService)
     {
         _userManager = userManager;
     }
@@ -28,7 +28,7 @@ public class UserTimelineModel : CheepTimelineModel
             int pageNr = getPageNr(Request);
             Console.WriteLine("pageQuery: " + pageNr + " author: " + author);
             Header = FormatPageHeader(Author);
-            Cheeps = await _service.GetCheepsFromUserName(author, pageNr);
+            Cheeps = await _cheepService.GetCheepsFromUserName(author, pageNr);
         }
         return Page();
     }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -4,6 +4,7 @@ using Chirp.Infrastructure;
 using Microsoft.Data.Sqlite;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +31,8 @@ if (environment.Equals("Development")) {
 
 builder.Services.AddScoped<ICheepRepository, CheepRepository>();
 builder.Services.AddScoped<ICheepService, CheepService>();
+builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
+builder.Services.AddScoped<IAuthorService, AuthorService>();
 builder.Services.AddDefaultIdentity<Author>(options => {
             options.SignIn.RequireConfirmedAccount = true;
         })

--- a/tests/Chirp.Infrastructure.Test/AuthorRepositoryTest.cs
+++ b/tests/Chirp.Infrastructure.Test/AuthorRepositoryTest.cs
@@ -1,0 +1,158 @@
+using Chirp.Core;
+using Chirp.Core.Domain_Model;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Chirp.Infrastructure.Test;
+
+public class AuthorRepositoryTest
+{
+    private readonly ChirpDBContext _context;
+    private SqliteConnection _connection;
+    private ICheepRepository _cheepRepository;
+    private IAuthorRepository _authorRepository;
+
+    public AuthorRepositoryTest()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<ChirpDBContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _context = new ChirpDBContext(options);
+        _context.Database.EnsureCreated();
+
+        _cheepRepository = new CheepRepository(_context);
+        _authorRepository = new AuthorRepository(_context);
+
+        DbInitializer.SeedDatabase(_context);
+
+        _context.SaveChanges();
+    }
+    [Fact]
+    public async Task attemptToFollowSelf()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors.Single();
+        //act
+        _ = _authorRepository.Follow(barton, barton);
+        //assert
+        Assert.Empty(await _authorRepository.GetFollowRelations(barton));
+    }
+
+    [Fact]
+    public async Task attemptToFollowSomeone()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors1= await _authorRepository.GetAuthor("WendellBallan");
+        Author Wendell = authors1.Single();
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        //act
+        _ = _authorRepository.Follow(barton, Wendell);
+        //assert
+        Assert.NotEmpty(await _authorRepository.GetFollowRelations(barton));
+    }
+
+    [Fact]
+    public async Task attemptToFollowSomeoneAlreadyFollowed()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors1= await _authorRepository.GetAuthor("WendellBallan");
+        Author Wendell = authors1.Single();
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        //act
+        _ = _authorRepository.Follow(barton, Wendell);
+        _ = _authorRepository.Follow(barton, Wendell);
+        List<Author> myList= await _authorRepository.Following(barton);
+        //assert
+        Assert.Single(myList);
+    }
+
+    [Fact]
+    public async Task attemptToUnfollowSomeoneFollowed()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors1= await _authorRepository.GetAuthor("WendellBallan");
+        Author Wendell = authors1.Single();
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        //act
+        _ = _authorRepository.Follow(barton, Wendell);
+        _ = _authorRepository.Unfollow(barton, Wendell);
+        //assert
+        Assert.Empty(await _authorRepository.GetFollowRelations(barton));
+    }
+
+    [Fact]
+    public async Task attemptToUnfollowSomeoneNotFollowed()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors1= await _authorRepository.GetAuthor("WendellBallan");
+        Author Wendell = authors1.Single();
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        //act
+        _ = _authorRepository.Unfollow(barton, Wendell);
+        //assert
+        Assert.Empty(await _authorRepository.GetFollowRelations(barton));
+    }
+
+    [Fact]
+    public async Task followNull()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        Author? Wendell = null;
+        //act
+        #pragma warning disable CS8604 // Possible null reference argument.
+        _ = _authorRepository.Follow(barton, Wendell);
+        //assert
+        Assert.Null(Wendell);
+        Assert.Empty(await _authorRepository.GetFollowRelations(barton));
+    }
+    [Fact]
+    public async Task followAuthorNotInDBContext()
+    {
+        //arrange
+        const string name = "Barton Cooper";
+        string username = name.Replace(" ", "");
+        const string email1 = "TheCakeMaster@copper.com";
+        await _authorRepository.CreateAuthor(name, email1);
+        List<Author> authors2= await _authorRepository.GetAuthor("BartonCooper");
+        Author barton = authors2.Single();
+        Author myAuthor = Author.Create("Bartoon2", "batman@gmail.com");
+        //act
+        _ = _authorRepository.Follow(barton, myAuthor);
+        //assert
+        Assert.Empty(await _authorRepository.GetFollowRelations(barton));
+    }
+}

--- a/tests/Chirp.Infrastructure.Test/CheepRepositoryTest.cs
+++ b/tests/Chirp.Infrastructure.Test/CheepRepositoryTest.cs
@@ -7,13 +7,14 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace Chirp.Web.Test;
+namespace Chirp.Infrastructure.Test;
 
 public class CheepRepositoryTest
 {
     private ChirpDBContext _context;
     private SqliteConnection _connection;
     private ICheepRepository _cheepRepository;
+    private IAuthorRepository _authorRepository;
 
     public CheepRepositoryTest()
     {
@@ -26,6 +27,7 @@ public class CheepRepositoryTest
         _context.Database.EnsureCreated();
 
         _cheepRepository = new CheepRepository(_context);
+        _authorRepository = new AuthorRepository(_context);
 
         DbInitializer.SeedDatabase(_context);
 
@@ -36,7 +38,7 @@ public class CheepRepositoryTest
     [InlineData("Helge", "ropf@itu.dk")]
     [InlineData("Adrian", "adho@itu.dk")]
     public async Task RequiredAuthorsExist(string name, string email) {
-        List<Author> authors = await _cheepRepository.GetAuthorByUserName(name);
+        List<Author> authors = await _authorRepository.GetAuthorByUserName(name);
         Assert.NotNull(authors);
         Assert.Single(authors);
         Author author = authors.Single();
@@ -200,7 +202,7 @@ public class CheepRepositoryTest
         string name, email;
         name = "Barton Cooper";
         email = "cooper@copper.com";
-        await _cheepRepository.CreateAuthor(name, email);
+        await _authorRepository.CreateAuthor(name, email);
         var query = (from author in _context.Authors
                      where author.DisplayName == name
                      select author);
@@ -215,8 +217,8 @@ public class CheepRepositoryTest
         name1 = "Barton Cooper";
         name2 = "Bar2n Cooper";
         email = "cooper@copper.com";
-        await _cheepRepository.CreateAuthor(name1, email);
-        await Assert.ThrowsAsync<DbUpdateException>(() => _cheepRepository.CreateAuthor(name2, email));
+        await _authorRepository.CreateAuthor(name1, email);
+        await Assert.ThrowsAsync<DbUpdateException>(() => _authorRepository.CreateAuthor(name2, email));
     }
 
     [Fact]
@@ -226,9 +228,9 @@ public class CheepRepositoryTest
         string username = name.Replace(" ", "");
         const string email1 = "TheCakeMaster@copper.com";
         const string email2 = "muffinEnjoyer@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        await Assert.ThrowsAsync<DbUpdateException>(() => _cheepRepository.CreateAuthor(name, email2));
-        List<Author> bartons = await _cheepRepository.GetAuthor(username);
+        await _authorRepository.CreateAuthor(name, email1);
+        await Assert.ThrowsAsync<DbUpdateException>(() => _authorRepository.CreateAuthor(name, email2));
+        List<Author> bartons = await _authorRepository.GetAuthor(username);
         Assert.Equal(name, bartons.Single().DisplayName);
         Assert.Equal(username, bartons.Single().UserName);
         Assert.Equal(email1, bartons.Single().Email);
@@ -237,7 +239,7 @@ public class CheepRepositoryTest
     [Fact]
     public async Task noKnownAuthorTest()
     {
-        List<Author> authorsFound = await _cheepRepository.GetAuthor("ThisNameorEmailDoesNotExist");
+        List<Author> authorsFound = await _authorRepository.GetAuthor("ThisNameorEmailDoesNotExist");
         Assert.Empty(authorsFound);
     }
 
@@ -247,7 +249,7 @@ public class CheepRepositoryTest
         string name, email;
         name = "";
         email = "cooper@copper.com";
-        await _cheepRepository.CreateAuthor(name, email);
+        await _authorRepository.CreateAuthor(name, email);
         var query = (from author in _context.Authors
                      where author.DisplayName == ""
                      select author);
@@ -258,7 +260,7 @@ public class CheepRepositoryTest
     [Fact]
     public async Task CheepOwnershipTest()
     {
-        List<Author> users = await _cheepRepository.GetAuthor("WendellBallan");
+        List<Author> users = await _authorRepository.GetAuthor("WendellBallan");
         string message = "I really like turtles";
         DateTime date = DateTime.Parse("2023-08-02 14:13:45");
         await _cheepRepository.CreateCheep(users.Single(), message, date);
@@ -285,7 +287,7 @@ public class CheepRepositoryTest
             select cheep);
         Assert.Empty(queryBefore);
 
-        List<Author> authors = await _cheepRepository.GetAuthor("WendellBallan");
+        List<Author> authors = await _authorRepository.GetAuthor("WendellBallan");
         Assert.NotEmpty(authors);
         DateTime date = DateTime.Parse("2023-08-02 13:13:45");
         await _cheepRepository.CreateCheep(authors.First(), message, date);
@@ -302,7 +304,7 @@ public class CheepRepositoryTest
     [Fact]
     public async Task CreateTooLongCheepTest()
     {
-        List<Author> authors = await _cheepRepository.GetAuthor("WendellBallan");
+        List<Author> authors = await _authorRepository.GetAuthor("WendellBallan");
         Assert.NotEmpty(authors);
         StringBuilder sb = new StringBuilder(160);
         while (sb.Length <= Cheep.MAX_TEXT_LENGTH) {
@@ -321,7 +323,7 @@ public class CheepRepositoryTest
     [Fact]
     public async Task CreateCheepAtExactlyLimit()
     {
-        List<Author> authors = await _cheepRepository.GetAuthor("WendellBallan");
+        List<Author> authors = await _authorRepository.GetAuthor("WendellBallan");
         Assert.NotEmpty(authors);
         StringBuilder sb = new StringBuilder(160);
         while (sb.Length < Cheep.MAX_TEXT_LENGTH) {
@@ -351,7 +353,7 @@ public class CheepRepositoryTest
     [Fact]
     public async Task CreateTooLongSQLInjectionCheepTest()
     {
-        List<Author> authors = await _cheepRepository.GetAuthor("WendellBallan");
+        List<Author> authors = await _authorRepository.GetAuthor("WendellBallan");
         Assert.NotEmpty(authors);
         StringBuilder sb = new StringBuilder(160);
         while (sb.Length <= Cheep.MAX_TEXT_LENGTH)
@@ -368,129 +370,5 @@ public class CheepRepositoryTest
             where cheep.Text == message
             select cheep);
         Assert.Empty(queryBefore);
-    }
-
-    [Fact]
-    public async Task attemptToFollowSelf()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors.Single();
-        //act
-        _ = _cheepRepository.Follow(barton, barton);
-        //assert
-        Assert.Empty(await _cheepRepository.GetFollowRelations(barton));
-    }
-
-    [Fact]
-    public async Task attemptToFollowSomeone()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors1= await _cheepRepository.GetAuthor("WendellBallan");
-        Author Wendell = authors1.Single();
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        //act
-        _ = _cheepRepository.Follow(barton, Wendell);
-        //assert
-        Assert.NotEmpty(await _cheepRepository.GetFollowRelations(barton));
-    }
-
-    [Fact]
-    public async Task attemptToFollowSomeoneAlreadyFollowed()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors1= await _cheepRepository.GetAuthor("WendellBallan");
-        Author Wendell = authors1.Single();
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        //act
-        _ = _cheepRepository.Follow(barton, Wendell);
-        _ = _cheepRepository.Follow(barton, Wendell);
-        List<Author> myList= await _cheepRepository.Following(barton);
-        //assert
-        Assert.Single(myList);
-    }
-
-    [Fact]
-    public async Task attemptToUnfollowSomeoneFollowed()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors1= await _cheepRepository.GetAuthor("WendellBallan");
-        Author Wendell = authors1.Single();
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        //act
-        _ = _cheepRepository.Follow(barton, Wendell);
-        _ = _cheepRepository.Unfollow(barton, Wendell);
-        //assert
-        Assert.Empty(await _cheepRepository.GetFollowRelations(barton));
-    }
-
-    [Fact]
-    public async Task attemptToUnfollowSomeoneNotFollowed()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors1= await _cheepRepository.GetAuthor("WendellBallan");
-        Author Wendell = authors1.Single();
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        //act
-        _ = _cheepRepository.Unfollow(barton, Wendell);
-        //assert
-        Assert.Empty(await _cheepRepository.GetFollowRelations(barton));
-    }
-
-    [Fact]
-    public async Task followNull()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        Author? Wendell = null;
-        //act
-        _ = _cheepRepository.Follow(barton, Wendell);
-        //assert
-        Assert.Empty(await _cheepRepository.GetFollowRelations(barton));
-    }
-    [Fact]
-    public async Task followAuthorNotInDBContext()
-    {
-        //arrange
-        const string name = "Barton Cooper";
-        string username = name.Replace(" ", "");
-        const string email1 = "TheCakeMaster@copper.com";
-        await _cheepRepository.CreateAuthor(name, email1);
-        List<Author> authors2= await _cheepRepository.GetAuthor("BartonCooper");
-        Author barton = authors2.Single();
-        Author myAuthor = Author.Create("Bartoon2", "batman@gmail.com");
-        //act
-        _ = _cheepRepository.Follow(barton, myAuthor);
-        //assert
-        Assert.Empty(await _cheepRepository.GetFollowRelations(barton));
     }
 }

--- a/tests/Chirp.Infrastructure.Test/Chirp.Infrastructure.Test.csproj
+++ b/tests/Chirp.Infrastructure.Test/Chirp.Infrastructure.Test.csproj
@@ -8,8 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.10" />
-      <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <ProjectReference Include="..\..\src\Chirp.Web\Chirp.Web.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A lot of the code that was changed was just moving files. I have created 2 classes + interfaces to each corresponding class, `IAuthorRepository.cs`, `AuthorRepository.cs`, `IAuthorService.cs`, and `AuthorService.cs`. Then have changed a few lines here and there so that they call the correct respository/service. 

`IAuthorService.cs`, and `AuthorService.cs` only contain one method because the other methods in `IAuthorRepository.cs`, `AuthorRepository.cs` are not in use in places only reachable by the service. 

 Futhermore I have created `AuthorRepositoryTest` and moved the repository tests to `tests\Chirp.Infrastructure.Test` instead of `tests\Chirp.Web.Test`